### PR TITLE
Handle no combo case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /heatmap*.json*
 /keymap*.yaml
+zmk-heatmap

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -39,11 +39,17 @@ var generateCmd = &cobra.Command{
 		sort.Slice(heatmap.KeyPresses, func(i, j int) bool {
 			return heatmap.KeyPresses[i].GetTotalPressCounts() < heatmap.KeyPresses[j].GetTotalPressCounts()
 		})
-		maxPress := heatmap.KeyPresses[len(heatmap.KeyPresses)-1].GetTotalPressCounts()
+		maxPress := 0
+		if len(heatmap.KeyPresses) > 0 {
+			maxPress = heatmap.KeyPresses[len(heatmap.KeyPresses)-1].GetTotalPressCounts()
+		}
 		sort.Slice(heatmap.ComboPresses, func(i, j int) bool {
 			return heatmap.ComboPresses[i].GetTotalPressCounts() < heatmap.ComboPresses[j].GetTotalPressCounts()
 		})
-		maxCombo := heatmap.ComboPresses[len(heatmap.ComboPresses)-1].GetTotalPressCounts()
+		maxCombo := 0
+		if len(heatmap.ComboPresses) > 0 {
+			maxCombo = heatmap.ComboPresses[len(heatmap.ComboPresses)-1].GetTotalPressCounts()
+		}
 
 		max := maxPress
 		if maxCombo > max {


### PR DESCRIPTION
When the log file doesn't contain any combos, it was experiencing a runtime error:
```
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
zmk-heatmap/cmd.init.func2(0x140000ca200?, {0x10440ef6c?, 0x4?, 0x10440ef70?})
        /Users/max/source/zmk-qmk-heatmap/cmd/generate.go:46 +0x5dc
github.com/spf13/cobra.(*Command).execute(0x104640c20, {0x14000084240, 0x4, 0x4})
        /Users/max/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0x81c
github.com/spf13/cobra.(*Command).ExecuteC(0x1046411e0)
        /Users/max/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/max/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
zmk-heatmap/cmd.Execute()
        /Users/max/source/zmk-qmk-heatmap/cmd/root.go:36 +0x24
main.main()
        /Users/max/source/zmk-qmk-heatmap/main.go:9 +0x1c
```

This PR addresses that issue by checking the length before reading to make sure we don't try and read from index -1.